### PR TITLE
Remove x264 direct dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,9 @@ version = "0.4.0"
 
 [deps]
 FFMPEG_jll = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-x264_jll = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
 
 [compat]
 FFMPEG_jll = "4.3.1"
-x264_jll = "2020.7.14"
 julia = "^1.3"
 
 [extras]


### PR DESCRIPTION
ffmpeg_jll now [compats itself with x264 ](https://github.com/JuliaRegistries/General/blob/a27c1ec5598e2a0c8ba7c07ea5e80d3afdda07b2/F/FFMPEG_jll/Compat.toml#L10-L12) so this isn't needed.

Also makes testing of an upcoming updated ffmpeg_jll easier