### PR TITLE
Use thread-safe call to `ffmpeg` in Julia v1.6

### DIFF
--- a/src/FFMPEG.jl
+++ b/src/FFMPEG.jl
@@ -103,13 +103,12 @@ built with clang version 6.0.1 (tags/RELEASE_601/final)
 ```
 """
 function exe(arg::Cmd; command = ffmpeg, collect = false)
-    if collect
-        command() do command_path
-            collectexecoutput(`$command_path $arg`)
-        end
+    f = collect ? collectexecoutput : Base.run
+    @static if VERSION ≥ v"1.6"
+        f(`$(command()) $arg`)
     else
         command() do command_path
-            Base.run(`$command_path $arg`)
+            f(`$command_path $arg`)
         end
     end
 end


### PR DESCRIPTION
Interestingly enough, this makes `exe` a bit more type-stable (a union type
instead of `Any`):

before:

``` julia
julia> @code_warntype FFMPEG.exe(`-version`);
Variables
  #self#::Core.Const(FFMPEG.exe)
  arg::Cmd

Body::Any
1 ─ %1 = FFMPEG.:(var"#exe#5")(FFMPEG.ffmpeg, false, #self#, arg)::Any
└──      return %1
```

after:

``` julia
julia> @code_warntype FFMPEG.exe(`-version`);
Variables
  #self#::Core.Const(FFMPEG.exe)
  arg::Cmd

Body::Union{Base.Process, Vector{String}}
1 ─ %1 = FFMPEG.:(var"#exe#10")(FFMPEG.ffmpeg, false, #self#, arg)::Union{Base.Process, Vector{String}}
└──      return %1
```